### PR TITLE
Added a 2nd argument (button pressed time before shutdown) and changed executable destination and owner.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ gpio-halt: gpio-halt.c
 	strip $@
 
 install:
-	mv $(EXECS) /usr/local/bin
+	mv $(EXECS) /usr/local/sbin
+	chown root:root /usr/local/sbin/$(EXECS)
 
 clean:
 	rm -f $(EXECS)

--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Press-to-halt program for headless Raspberry Pi. Similar functionality to the rp
 # Modifications
 - Added a second argument, the time (in milliseconds) that the button should be kept pressed for halt to start.
 First argument, which was present in the original, is the GPIO pin (21 by default).
-- `Make install` will copy the executable to /usr/local/sbin (instead of /usr/local/bin) and set root as the owner
+- `Make install` will copy the executable to /usr/local/sbin (instead of /usr/local/bin) and set root as the owner. This makes more sense as power handling commands are usually owned by root and located in sbin directories.

--- a/README.md
+++ b/README.md
@@ -4,5 +4,6 @@ Adafruit-GPIO-Halt
 Press-to-halt program for headless Raspberry Pi. Similar functionality to the rpi_power_switch kernel module from the fbtft project, but easier to compile (no kernel headers needed).
 
 # Modifications
-Added a second argument, the time (in milliseconds) that the button should be kept pressed for halt to start.
+- Added a second argument, the time (in milliseconds) that the button should be kept pressed for halt to start.
 First argument, which was present in the original, is the GPIO pin (21 by default).
+- `Make install` will copy the executable to /usr/local/sbin (instead of /usr/local/bin) and set root as the owner

--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@ Adafruit-GPIO-Halt
 
 Press-to-halt program for headless Raspberry Pi. Similar functionality to the rpi_power_switch kernel module from the fbtft project, but easier to compile (no kernel headers needed).
 
-# Modification:
+# Modifications
 Added a second argument, the time (in milliseconds) that the button should be kept pressed for halt to start.
 First argument, which was present in the original, is the GPIO pin (21 by default).

--- a/README.md
+++ b/README.md
@@ -7,3 +7,37 @@ Press-to-halt program for headless Raspberry Pi. Similar functionality to the rp
 - Added a second argument, the time (in milliseconds) that the button should be kept pressed for halt to start.
 First argument, which was present in the original, is the GPIO pin (21 by default).
 - `Make install` will copy the executable to /usr/local/sbin (instead of /usr/local/bin) and set root as the owner. This makes more sense as power handling commands are usually owned by root and located in sbin directories.
+
+## Install as a service 
+(Based on this blog post: https://www.recantha.co.uk/blog/?p=13999)
+
+Create and open service file:
+```
+sudo vi /etc/systemd/system/gpio-halt.service
+```
+Add this content to the file:
+```
+[Unit]
+Description=GPIO shutdown (pin 21 to ground)
+After=multi-user.target
+
+[Service]
+Type=idle
+ExecStart=/usr/local/sbin/gpio-halt 21 3000
+
+[Install]
+WantedBy=multi-user.target
+```
+Start the script:
+```
+sudo systemctl daemon-reload
+sudo systemctl start gpio-halt.service
+```
+Make the service run every time the system boots:
+```
+sudo systemctl enable gpio-halt.service
+```
+If you want to check the status of the service:
+```
+sudo systemctl status gpio-halt.service
+```

--- a/README.md
+++ b/README.md
@@ -2,3 +2,7 @@ Adafruit-GPIO-Halt
 ==================
 
 Press-to-halt program for headless Raspberry Pi. Similar functionality to the rpi_power_switch kernel module from the fbtft project, but easier to compile (no kernel headers needed).
+
+# Modification:
+Added a second argument, the time (in milliseconds) that the button should be kept pressed for halt to start.
+First argument, which was present in the original, is the GPIO pin (21 by default).

--- a/gpio-halt.c
+++ b/gpio-halt.c
@@ -72,7 +72,7 @@ int
    pin          = 21;                // Shutdown pin # (override w/argv)
 volatile unsigned int
   *gpio;                             // GPIO register table
-const int
+int
    debounceTime = 20;                // 20 ms for button debouncing
 
 
@@ -177,6 +177,9 @@ int main(int argc, char *argv[]) {
 	signal(SIGKILL, signalHandler);
 
 	if(argc > 1) pin = atoi(argv[1]);
+	// Second argument is the time (in milliseconds) that the button
+    	// should be kept pressed for shutdown to start
+    	if(argc > 2) debounceTime = debounceTime + atoi(argv[2]);
 
 	// If this is a "Revision 1" Pi board (no mounting holes),
 	// remap certain pin numbers for compatibility.


### PR DESCRIPTION
Modifications:
- Added a second argument, the time (in milliseconds) that the button should be kept pressed for halt to start. First argument, which was present in the original, is the GPIO pin (21 by default).
- Make install will copy the executable to /usr/local/sbin (instead of /usr/local/bin) and set root as the owner. This makes more sense as power handling commands are usually owned by root and located in sbin directories.